### PR TITLE
Feature/close capture fragment on permission denied

### DIFF
--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
@@ -107,6 +107,8 @@ class PickPicCaptureFragment : DialogFragment() {
             val deniedPermissions = Permission.getDeniedPermissions(requireActivity(), Permission.cameraPermissions.plus(Permission.galleryPermissions))
             if (deniedPermissions.isEmpty()) {
                 startCamera()
+            } else {
+                dismiss()
             }
         }
     }

--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
@@ -108,7 +108,8 @@ class PickPicCaptureFragment : DialogFragment() {
             if (deniedPermissions.isEmpty()) {
                 startCamera()
             } else {
-                dismiss()
+                captureCallback?.onCapture(null)
+                dismissAllowingStateLoss()
             }
         }
     }


### PR DESCRIPTION
when PickPic is used over PickPicCaptureFragment and the user declines the permission, the dialog is never closed