### PR TITLE
Fix/pass context to workermanager

### DIFF
--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
@@ -107,7 +107,7 @@ class PickPicCaptureFragment : DialogFragment() {
 
         val destination = captureDestination
         if (resultCode == Activity.RESULT_OK && destination != null) {
-            CaptureResultWorker.start(destination, WORKER_NAME)
+            CaptureResultWorker.start(requireContext().applicationContext, destination, WORKER_NAME)
         } else {
             captureCallback?.onCapture(null)
             dismissAllowingStateLoss()

--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/worker/CaptureResultWorker.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/worker/CaptureResultWorker.kt
@@ -33,6 +33,7 @@ import com.lovoo.android.pickcore.loader.CameraLoader
 import com.lovoo.android.pickcore.util.isMinimumQ
 import io.reactivex.Single
 import java.io.File
+import android.content.Context
 
 /**
  * Worker that handles all the tasks to finalize the captured image from the camera.
@@ -96,7 +97,7 @@ class CaptureResultWorker(
          * @param destination the [CameraDestination] that was used to capture the picture
          * @param name optional unique name for the [Worker] (default: CaptureResultWorker)
          */
-        fun start(destination: CameraDestination, name: String = "CaptureResultWorker") {
+        fun start(context: Context, destination: CameraDestination, name: String = "CaptureResultWorker") {
             val data = workDataOf(
                 INPUT_IS_PUBLIC to (destination !is PrivateDirectory),
                 INPUT_FILE to (destination.file?.path ?: "")
@@ -106,7 +107,7 @@ class CaptureResultWorker(
                 .setInputData(data)
                 .build()
 
-            WorkManager.getInstance().enqueueUniqueWork(name, ExistingWorkPolicy.REPLACE, request)
+            WorkManager.getInstance(context).enqueueUniqueWork(name, ExistingWorkPolicy.REPLACE, request)
         }
     }
 }


### PR DESCRIPTION
use `workManager#getInstance(context)` as the `getInstance()` is deprecated and will prevent other apps from using PicPick due to dagger factories can't inject the worker class. 