### PR TITLE
Fix for "EXPORTED" flags in the registering of broadcast receivers

### DIFF
--- a/app/src/main/kotlin/com/lovoo/android/pickpic/ExampleActivity.kt
+++ b/app/src/main/kotlin/com/lovoo/android/pickpic/ExampleActivity.kt
@@ -45,7 +45,7 @@ class ExampleActivity : AppCompatActivity() {
                     maxCount = 10,
                     sendIcon = R.drawable.ic_send,
                     header = getString(R.string.pickpic_actionbar_header),
-                    title = getString(R.string.pickpic_title)
+                    title = getString(R.string.pickpic_title),
                 )
                 // pass the config to PickPic
                 PickPicActivity.applyConfig(it, config)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.6.21'
     ext.multidex_version = "2.0.1"
 
     ext.legacy_v4_version = "1.0.0"
@@ -53,10 +53,10 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.18'
-        classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.27.1'
+        classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.22.0'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/adapter/PickPicAdapter.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/adapter/PickPicAdapter.kt
@@ -34,7 +34,7 @@ import com.lovoo.android.pickui.view.GalleryFragment
 class PickPicAdapter(
     private val context: Context,
     manager: FragmentManager,
-    private val dependencies: PickDependencies
+    private val dependencies: PickDependencies,
 ) : FragmentStatePagerAdapter(manager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
     override fun getItem(position: Int) = buildFragment(getType(position))

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/adapter/SelectionAdapter.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/adapter/SelectionAdapter.kt
@@ -109,7 +109,7 @@ class SelectionAdapter(
 
     class ViewHolder(
         view: View,
-        private val imageEngine: ImageEngine
+        private val imageEngine: ImageEngine,
     ) : RecyclerView.ViewHolder(view) {
         private val size = view.context.resources.getDimensionPixelSize(R.dimen.pickpic_thumbnail_size)
         private val corner = view.context.resources.getDimensionPixelSize(R.dimen.pickpic_thumbnail_corner_size)

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/factory/GlideEngine.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/factory/GlideEngine.kt
@@ -70,9 +70,12 @@ class GlideEngine : ImageEngine {
                 RequestOptions()
                     .override(width, height)
                     .also {
-                        if (corner > 0) it.transform(CenterCrop(), RoundedCorners(corner))
-                        else it.centerCrop()
-                    }
+                        if (corner > 0) {
+                            it.transform(CenterCrop(), RoundedCorners(corner))
+                        } else {
+                            it.centerCrop()
+                        }
+                    },
             )
             .apply {
                 if (errorRes != 0) {

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/model/PickPicConfig.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/model/PickPicConfig.kt
@@ -43,7 +43,7 @@ data class PickPicConfig(
     val sendText: String? = null,
     @DrawableRes val sendIcon: Int? = null,
     val header: String? = null,
-    val faqUrl: String? = null
+    val faqUrl: String? = null,
 ) : Parcelable {
 
     constructor(parcel: Parcel) : this(
@@ -54,7 +54,7 @@ data class PickPicConfig(
         parcel.readString(),
         parcel.readValue(Int::class.java.classLoader) as? Int,
         parcel.readString(),
-        parcel.readString()
+        parcel.readString(),
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/model/PickType.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/model/PickType.kt
@@ -21,5 +21,5 @@ package com.lovoo.android.pickapp.model
  */
 enum class PickType {
     GALLERY,
-    FACEBOOK
+    FACEBOOK,
 }

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/model/Picker.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/model/Picker.kt
@@ -30,7 +30,7 @@ import io.reactivex.subjects.BehaviorSubject
  * @param config the [PickConfig] to determine the limits
  */
 class Picker(
-    val config: PickConfig
+    val config: PickConfig,
 ) {
 
     /**
@@ -136,7 +136,7 @@ class Picker(
      */
     data class PickConfig(
         val minCount: Int = 1,
-        val maxCount: Int = 1
+        val maxCount: Int = 1,
     )
 
     sealed class State {
@@ -148,7 +148,7 @@ class Picker(
          */
         data class Select(
             val position: Int,
-            val uri: Uri?
+            val uri: Uri?,
         ) : State()
 
         /**
@@ -159,7 +159,7 @@ class Picker(
          */
         data class Add(
             val uri: Uri,
-            val gallery: Gallery
+            val gallery: Gallery,
         ) : State()
 
         /**
@@ -170,7 +170,7 @@ class Picker(
          */
         data class Remove(
             val uri: Uri,
-            val gallery: Gallery
+            val gallery: Gallery,
         ) : State()
     }
 }

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/PickPicActivity.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/PickPicActivity.kt
@@ -85,7 +85,7 @@ class PickPicActivity : AppCompatActivity(), SelectionHolder, CameraEngine, Capt
             maxCount = 10,
             sendText = "DONE",
             title = getString(R.string.pickpic_title),
-            header = getString(R.string.pickpic_actionbar_header)
+            header = getString(R.string.pickpic_actionbar_header),
         )
 
         config = intent?.getParcelableExtra(INTENT_IN_CONFIG) ?: default
@@ -140,8 +140,9 @@ class PickPicActivity : AppCompatActivity(), SelectionHolder, CameraEngine, Capt
         try {
             val uris = savedInstanceState.getParcelableArray(BUNDLE_URIS)?.map { it as Uri }?.toTypedArray()
             val galleries = savedInstanceState.getParcelableArray(BUNDLE_GALLERIES)?.map { it as Gallery }?.toTypedArray()
-            if (uris != null && galleries != null)
+            if (uris != null && galleries != null) {
                 picker.toggle(uris, galleries)
+            }
         } catch (e: Exception) {
             e.printStackTrace()
         }
@@ -219,8 +220,8 @@ class PickPicActivity : AppCompatActivity(), SelectionHolder, CameraEngine, Capt
                         is Picker.State.Select -> selectedUri = state.uri
                     }
                 },
-                { error -> error.printStackTrace() }
-            )
+                { error -> error.printStackTrace() },
+            ),
         )
     }
 
@@ -233,12 +234,12 @@ class PickPicActivity : AppCompatActivity(), SelectionHolder, CameraEngine, Capt
                             {
                                 finishSelection()
                             },
-                            AUTO_FINISH_DELAY
+                            AUTO_FINISH_DELAY,
                         )
                     }
                 },
-                { /* no-op */ }
-            )
+                { /* no-op */ },
+            ),
         )
     }
 
@@ -298,7 +299,7 @@ class PickPicActivity : AppCompatActivity(), SelectionHolder, CameraEngine, Capt
                             this.paddingStart,
                             this.paddingTop,
                             this.paddingEnd,
-                            resources.getDimensionPixelOffset(R.dimen.pickpic_actionbar_headline_margin)
+                            resources.getDimensionPixelOffset(R.dimen.pickpic_actionbar_headline_margin),
                         )
                     }
                     (toolbar.layoutParams as CollapsingToolbarLayout.LayoutParams).collapseMode =
@@ -314,9 +315,8 @@ class PickPicActivity : AppCompatActivity(), SelectionHolder, CameraEngine, Capt
         selectionbar = Selectionbar(
             picker,
             binding.selectionBar,
-            arrayOf(binding.fragmentPager, binding.previewPager)
+            arrayOf(binding.fragmentPager, binding.previewPager),
         ).apply {
-
             setButtonText(this@PickPicActivity.config.sendText)
             setButtonIcon(this@PickPicActivity.config.sendIcon)
             setButtonOnClick { finishSelection() }

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/Preview.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/Preview.kt
@@ -35,7 +35,7 @@ import io.reactivex.disposables.CompositeDisposable
 class Preview(
     val pager: ViewPager,
     val fragmentManager: FragmentManager,
-    val picker: Picker
+    val picker: Picker,
 ) {
 
     private val subscriptions = CompositeDisposable()
@@ -77,8 +77,8 @@ class Preview(
                         }
                     }
                 },
-                { error -> error.printStackTrace() }
-            )
+                { error -> error.printStackTrace() },
+            ),
         )
     }
 
@@ -87,7 +87,7 @@ class Preview(
             it.adapter = object : FragmentStatePagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
                 override fun getItem(position: Int) = PreviewFragment.createInstance(
                     position,
-                    picker.getPickedUris().getOrNull(position)
+                    picker.getPickedUris().getOrNull(position),
                 )
 
                 override fun getCount() = picker.map.size

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/PreviewFragment.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/PreviewFragment.kt
@@ -64,7 +64,7 @@ class PreviewFragment : Fragment() {
                     it.measuredHeight,
                     uri,
                     it,
-                    0
+                    0,
                 )
             }
         }

--- a/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/Selectionbar.kt
+++ b/pickapp/src/main/kotlin/com/lovoo/android/pickapp/view/Selectionbar.kt
@@ -49,7 +49,7 @@ import io.reactivex.disposables.CompositeDisposable
 class Selectionbar(
     private val picker: Picker,
     private val binding: PickpicLayoutSelectionbarBinding,
-    private val dependingViews: Array<View>
+    private val dependingViews: Array<View>,
 ) {
 
     private val adapter = SelectionAdapter(picker.config.maxCount)
@@ -201,8 +201,8 @@ class Selectionbar(
                         }
                     }
                 },
-                { error -> error.printStackTrace() }
-            )
+                { error -> error.printStackTrace() },
+            ),
         )
     }
 

--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
@@ -16,12 +16,20 @@
 package com.lovoo.android.pickcam.view
 
 import android.app.Activity
-import android.content.*
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
-import android.os.*
-import android.view.*
+import android.os.Build
+import android.os.Bundle
+import android.os.Environment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.*
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
 import com.lovoo.android.pickcam.R
 import com.lovoo.android.pickcam.worker.CaptureResultWorker
 import com.lovoo.android.pickcore.contract.CameraDestination

--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/view/PickPicCaptureFragment.kt
@@ -16,21 +16,12 @@
 package com.lovoo.android.pickcam.view
 
 import android.app.Activity
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
+import android.content.*
 import android.content.pm.PackageManager
-import android.os.Build
-import android.os.Bundle
-import android.os.Environment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.os.*
+import android.view.*
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.*
 import com.lovoo.android.pickcam.R
 import com.lovoo.android.pickcam.worker.CaptureResultWorker
 import com.lovoo.android.pickcore.contract.CameraDestination
@@ -40,6 +31,7 @@ import com.lovoo.android.pickcore.destination.PublicDirectory
 import com.lovoo.android.pickcore.loader.CameraLoader
 import com.lovoo.android.pickcore.permission.Permission
 import com.lovoo.android.pickcore.util.isMinimumR
+import com.lovoo.android.pickcore.util.registerReceiverSafely
 
 /**
  * Ready to use solution to handle Android Camera capture.
@@ -81,7 +73,10 @@ class PickPicCaptureFragment : DialogFragment() {
                 throw (IllegalArgumentException("You have to implement CaptureCallback"))
             }
         }
-        context.registerReceiver(onWorkerDoneReceiver, IntentFilter().apply { addAction(CaptureResultWorker.INTENT_ACTION_ON_RESULT) })
+        context.registerReceiverSafely(
+            receiver = onWorkerDoneReceiver,
+            filter = IntentFilter().apply { addAction(CaptureResultWorker.INTENT_ACTION_ON_RESULT) },
+        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -131,7 +126,8 @@ class PickPicCaptureFragment : DialogFragment() {
                 preferences.edit().putBoolean(PREF_KEY_PERMISSION, false).apply()
             }
 
-            val deniedPermissions = Permission.getDeniedPermissions(requireActivity(), Permission.cameraPermissions.plus(Permission.galleryPermissions))
+            val deniedPermissions =
+                Permission.getDeniedPermissions(requireActivity(), Permission.cameraPermissions.plus(Permission.galleryPermissions))
             if (deniedPermissions.isEmpty()) {
                 startCamera()
             } else {

--- a/pickcam/src/main/kotlin/com/lovoo/android/pickcam/worker/CaptureResultWorker.kt
+++ b/pickcam/src/main/kotlin/com/lovoo/android/pickcam/worker/CaptureResultWorker.kt
@@ -48,7 +48,7 @@ import java.io.File
  */
 class CaptureResultWorker(
     private val context: Context,
-    params: WorkerParameters
+    params: WorkerParameters,
 ) : RxWorker(context, params) {
 
     private var inputFile: File = File(params.inputData.getString(INPUT_FILE))
@@ -72,7 +72,7 @@ class CaptureResultWorker(
                     // LiveData holds to long the old result so we have to forward the result as broadcast
                     context.sendBroadcast(Intent(INTENT_ACTION_ON_RESULT).putExtra(OUTPUT_URI, uri))
                     emitter.onSuccess(Result.success())
-                }
+                },
             )
         }
     }
@@ -99,7 +99,7 @@ class CaptureResultWorker(
         fun start(context: Context, destination: CameraDestination, name: String = "CaptureResultWorker") {
             val data = workDataOf(
                 INPUT_IS_PUBLIC to (destination !is PrivateDirectory),
-                INPUT_FILE to (destination.file?.path ?: "")
+                INPUT_FILE to (destination.file?.path ?: ""),
             )
 
             val request = OneTimeWorkRequest.Builder(CaptureResultWorker::class.java)

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/contract/CameraDestination.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/contract/CameraDestination.kt
@@ -55,7 +55,6 @@ fun CameraDestination.getUri(context: Context): Uri? = when {
  * @param fileName optional complete filename or if not set JPEG_<date>.jpg
  */
 fun CameraDestination.createTempFile(fileName: String = ""): File? {
-
     if (Environment.MEDIA_MOUNTED != EnvironmentCompat.getStorageState(directory)) {
         // the storage state is broken
         return null

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/loader/Collector.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/loader/Collector.kt
@@ -34,7 +34,7 @@ import androidx.loader.content.Loader
 class Collector(
     private val manager: LoaderManager,
     private val loader: Loader<Cursor>,
-    private val id: Int
+    private val id: Int,
 ) : LoaderManager.LoaderCallbacks<Cursor> {
 
     /**

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/loader/GalleryLoader.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/loader/GalleryLoader.kt
@@ -37,29 +37,33 @@ import com.lovoo.android.pickcore.util.isMinimumQ
  * @see GalleryLoader.convert
  */
 class GalleryLoader(
-    context: Context
+    context: Context,
 ) : CursorLoader(
     context,
     query,
     projection,
     selection,
     selectArguments,
-    "${MediaStore.Images.Media.DISPLAY_NAME} ASC"
+    "${MediaStore.Images.Media.DISPLAY_NAME} ASC",
 ) {
 
-    private val columns = if (isMinimumQ()) arrayOf(
-        MediaStore.Files.FileColumns._ID,
-        COLUMN_NAME_ID,
-        COLUMN_NAME_DISPLAY_NAME,
-        MediaStore.Images.Media._ID,
-        COLUMN_NAME_COUNT
-    ) else arrayOf(
-        MediaStore.Files.FileColumns._ID,
-        COLUMN_NAME_ID,
-        COLUMN_NAME_DISPLAY_NAME,
-        MediaStore.MediaColumns.DATA,
-        COLUMN_NAME_COUNT
-    )
+    private val columns = if (isMinimumQ()) {
+        arrayOf(
+            MediaStore.Files.FileColumns._ID,
+            COLUMN_NAME_ID,
+            COLUMN_NAME_DISPLAY_NAME,
+            MediaStore.Images.Media._ID,
+            COLUMN_NAME_COUNT,
+        )
+    } else {
+        arrayOf(
+            MediaStore.Files.FileColumns._ID,
+            COLUMN_NAME_ID,
+            COLUMN_NAME_DISPLAY_NAME,
+            MediaStore.MediaColumns.DATA,
+            COLUMN_NAME_COUNT,
+        )
+    }
 
     override fun loadInBackground(): Cursor {
         return try {
@@ -130,8 +134,8 @@ class GalleryLoader(
                             bucketId.toString(),
                             bucketDisplayName,
                             uri.toString(),
-                            count.toString()
-                        )
+                            count.toString(),
+                        ),
                     )
 
                     done.add(bucketId)
@@ -146,8 +150,8 @@ class GalleryLoader(
                 -1,
                 Constants.All_FOLDER_NAME,
                 allAlbumCoverUri?.toString(),
-                totalCount
-            )
+                totalCount,
+            ),
         )
 
         return MergeCursor(arrayOf<Cursor>(allEntry, otherAlbums))
@@ -159,19 +163,22 @@ class GalleryLoader(
         private const val COLUMN_NAME_COUNT = "count"
 
         private val query = MediaStore.Files.getContentUri("external")
-        private val projection = if (isMinimumQ()) arrayOf(
-            MediaStore.Files.FileColumns._ID,
-            COLUMN_NAME_ID,
-            COLUMN_NAME_DISPLAY_NAME,
-            MediaStore.Images.Media._ID
-        ) else
+        private val projection = if (isMinimumQ()) {
+            arrayOf(
+                MediaStore.Files.FileColumns._ID,
+                COLUMN_NAME_ID,
+                COLUMN_NAME_DISPLAY_NAME,
+                MediaStore.Images.Media._ID,
+            )
+        } else {
             arrayOf(
                 MediaStore.Files.FileColumns._ID,
                 COLUMN_NAME_ID,
                 COLUMN_NAME_DISPLAY_NAME,
                 MediaStore.MediaColumns.DATA,
-                "COUNT(*) AS $COLUMN_NAME_COUNT"
+                "COUNT(*) AS $COLUMN_NAME_COUNT",
             )
+        }
         private val group = if (isMinimumQ()) "" else ") GROUP BY ($COLUMN_NAME_ID"
         private val selection = "${MediaStore.Files.FileColumns.MEDIA_TYPE}=? AND ${MediaStore.MediaColumns.SIZE}>0$group"
         private val selectArguments = arrayOf(MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString())
@@ -190,17 +197,21 @@ class GalleryLoader(
          * @param cursor the [Cursor]
          * @return the [GalleryLib] object with the data from the [Cursor]
          */
-        fun convert(cursor: Cursor) = if (isMinimumQ()) GalleryLib(
-            cursor.getString(cursor.getColumnIndex(COLUMN_NAME_ID)),
-            getUri(cursor)?.toString(),
-            cursor.getString(cursor.getColumnIndex(COLUMN_NAME_DISPLAY_NAME)),
-            cursor.getLong(cursor.getColumnIndex(COLUMN_NAME_COUNT))
-        ) else GalleryLib(
-            cursor.getString(cursor.getColumnIndex(COLUMN_NAME_ID)),
-            cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DATA)),
-            cursor.getString(cursor.getColumnIndex(COLUMN_NAME_DISPLAY_NAME)),
-            cursor.getLong(cursor.getColumnIndex(COLUMN_NAME_COUNT))
-        )
+        fun convert(cursor: Cursor) = if (isMinimumQ()) {
+            GalleryLib(
+                cursor.getString(cursor.getColumnIndex(COLUMN_NAME_ID)),
+                getUri(cursor)?.toString(),
+                cursor.getString(cursor.getColumnIndex(COLUMN_NAME_DISPLAY_NAME)),
+                cursor.getLong(cursor.getColumnIndex(COLUMN_NAME_COUNT)),
+            )
+        } else {
+            GalleryLib(
+                cursor.getString(cursor.getColumnIndex(COLUMN_NAME_ID)),
+                cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DATA)),
+                cursor.getString(cursor.getColumnIndex(COLUMN_NAME_DISPLAY_NAME)),
+                cursor.getLong(cursor.getColumnIndex(COLUMN_NAME_COUNT)),
+            )
+        }
 
         private fun getUri(cursor: Cursor): Uri? {
             val id = cursor.getLong(cursor.getColumnIndex(MediaStore.Files.FileColumns._ID))

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/loader/PictureLoader.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/loader/PictureLoader.kt
@@ -39,14 +39,14 @@ import com.lovoo.android.pickcore.model.PictureLib
  */
 class PictureLoader(
     context: Context,
-    private val gallery: GalleryLib
+    private val gallery: GalleryLib,
 ) : CursorLoader(
     context,
     query,
     projection,
     getSelection(gallery),
     getSelectionArgs(gallery),
-    "${MediaStore.Images.Media.DATE_ADDED} DESC"
+    "${MediaStore.Images.Media.DATE_ADDED} DESC",
 ) {
 
     private val cameraEngine: CameraEngine
@@ -82,7 +82,7 @@ class PictureLoader(
             MediaStore.Files.FileColumns._ID,
             MediaStore.MediaColumns.DISPLAY_NAME,
             MediaStore.MediaColumns.MIME_TYPE,
-            MediaStore.MediaColumns.SIZE
+            MediaStore.MediaColumns.SIZE,
         )
 
         private fun getSelection(gallery: GalleryLib) = when (gallery.name) {
@@ -113,7 +113,7 @@ class PictureLoader(
         fun convert(cursor: Cursor) = PictureLib(
             cursor.getLong(cursor.getColumnIndex(MediaStore.Files.FileColumns._ID)),
             cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE)),
-            cursor.getLong(cursor.getColumnIndex(MediaStore.MediaColumns.SIZE))
+            cursor.getLong(cursor.getColumnIndex(MediaStore.MediaColumns.SIZE)),
         )
     }
 }

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/Converter.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/Converter.kt
@@ -21,7 +21,7 @@ package com.lovoo.android.pickcore.model
 fun Picture.convertToLib() = PictureLib(
     id,
     mimeType,
-    size
+    size,
 )
 
 /**
@@ -30,7 +30,7 @@ fun Picture.convertToLib() = PictureLib(
 fun PictureLib.convertToUi() = Picture(
     id,
     mimeType ?: "",
-    size ?: 0L
+    size ?: 0L,
 )
 
 /**
@@ -40,7 +40,7 @@ fun Gallery.convertToLib() = GalleryLib(
     id,
     coverPath,
     name,
-    count
+    count,
 )
 
 /**
@@ -50,5 +50,5 @@ fun GalleryLib.convertToUi() = Gallery(
     id ?: "",
     coverPath ?: "",
     name ?: "",
-    count ?: 0L
+    count ?: 0L,
 )

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/Gallery.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/Gallery.kt
@@ -30,14 +30,14 @@ data class Gallery(
     val id: String,
     val coverPath: String,
     val name: String,
-    val count: Long
+    val count: Long,
 ) : Parcelable {
 
     constructor(parcel: Parcel) : this(
         parcel.readString() ?: "",
         parcel.readString() ?: "",
         parcel.readString() ?: "",
-        parcel.readLong()
+        parcel.readLong(),
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/GalleryLib.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/GalleryLib.kt
@@ -27,5 +27,5 @@ data class GalleryLib(
     val id: String? = "",
     val coverPath: String? = "",
     val name: String? = "",
-    val count: Long? = 0L
+    val count: Long? = 0L,
 )

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/Picture.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/Picture.kt
@@ -31,13 +31,13 @@ import android.provider.MediaStore
 data class Picture(
     val id: Long,
     val mimeType: String,
-    val size: Long
+    val size: Long,
 ) : Parcelable {
 
     constructor(parcel: Parcel) : this(
         parcel.readLong(),
         parcel.readString() ?: "",
-        parcel.readLong()
+        parcel.readLong(),
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/PictureLib.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/model/PictureLib.kt
@@ -25,5 +25,5 @@ package com.lovoo.android.pickcore.model
 data class PictureLib(
     val id: Long,
     val mimeType: String? = "",
-    val size: Long? = 0L
+    val size: Long? = 0L,
 )

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/util/ContextExtensions.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/util/ContextExtensions.kt
@@ -15,8 +15,30 @@
  */
 package com.lovoo.android.pickcore.util
 
+import android.annotation.SuppressLint
+import android.content.*
 import android.os.Build
 
 fun isMinimumQ() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 
 fun isMinimumR() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+
+/**
+ * Registers given [receiver] for all Android versions, including Android 13+, where the "EXPORTED" nature of the receiver must be explicitly passed
+ * to the parameters.
+ *
+ * @param isExported indicates if the BroadcastReceiver is exported or not (i.e. available to external apps). False by default.
+ */
+@SuppressLint("UnspecifiedRegisterReceiverFlag")
+fun Context.registerReceiverSafely(
+    receiver: BroadcastReceiver,
+    filter: IntentFilter,
+    isExported: Boolean = false
+) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val exportedFlag = if (isExported) Context.RECEIVER_EXPORTED else Context.RECEIVER_NOT_EXPORTED
+        registerReceiver(receiver, filter, exportedFlag)
+    } else {
+        registerReceiver(receiver, filter)
+    }
+}

--- a/pickcore/src/main/kotlin/com/lovoo/android/pickcore/util/ContextExtensions.kt
+++ b/pickcore/src/main/kotlin/com/lovoo/android/pickcore/util/ContextExtensions.kt
@@ -16,7 +16,9 @@
 package com.lovoo.android.pickcore.util
 
 import android.annotation.SuppressLint
-import android.content.*
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
 import android.os.Build
 
 fun isMinimumQ() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
@@ -33,7 +35,7 @@ fun isMinimumR() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 fun Context.registerReceiverSafely(
     receiver: BroadcastReceiver,
     filter: IntentFilter,
-    isExported: Boolean = false
+    isExported: Boolean = false,
 ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         val exportedFlag = if (isExported) Context.RECEIVER_EXPORTED else Context.RECEIVER_NOT_EXPORTED

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/Facebook.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/Facebook.kt
@@ -54,8 +54,8 @@ class Facebook {
                     User(
                         currentProfile.id,
                         currentProfile.name,
-                        currentProfile.getProfilePictureUri(1000, 1000).path ?: ""
-                    )
+                        currentProfile.getProfilePictureUri(1000, 1000).path ?: "",
+                    ),
                 )
             }
         }
@@ -86,9 +86,8 @@ class Facebook {
     fun requestAccessToken(
         fragment: Fragment,
         permissions: List<String> = listOf("public_profile"),
-        callback: FacebookCallback<LoginResult>?
+        callback: FacebookCallback<LoginResult>?,
     ) {
-
         LoginManager.getInstance().apply {
             registerCallback(callbackManager, callback)
         }.logInWithReadPermissions(fragment, permissions)
@@ -222,6 +221,6 @@ class Facebook {
     data class User(
         val id: String,
         val name: String,
-        val picture: String
+        val picture: String,
     )
 }

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/adapter/FbGalleryAdapter.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/adapter/FbGalleryAdapter.kt
@@ -36,7 +36,7 @@ import com.lovoo.android.pickfacebook.R
  */
 class FbGalleryAdapter(
     context: Context,
-    private val onClick: (View, Gallery) -> Unit
+    private val onClick: (View, Gallery) -> Unit,
 ) : RecyclerView.Adapter<FbGalleryAdapter.ViewHolder>() {
 
     private val inflater = LayoutInflater.from(context)
@@ -77,7 +77,7 @@ class FbGalleryAdapter(
     class ViewHolder(
         view: View,
         private val engine: ImageEngine,
-        private val onClick: (View, Gallery) -> Unit
+        private val onClick: (View, Gallery) -> Unit,
     ) : RecyclerView.ViewHolder(view) {
 
         fun bind(gallery: Gallery) {
@@ -93,7 +93,7 @@ class FbGalleryAdapter(
                         itemView.measuredWidth,
                         Uri.parse(gallery.coverPath),
                         itemView.findViewById(R.id.gallery_cover),
-                        0
+                        0,
                     )
                     return true
                 }

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/adapter/FbPictureAdapter.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/adapter/FbPictureAdapter.kt
@@ -36,7 +36,7 @@ import com.lovoo.android.pickfacebook.model.FbPicture
 class FbPictureAdapter(
     context: Context,
     private val selectionLookUp: (FbPicture) -> Boolean,
-    private val onClick: (View, FbPicture) -> Unit
+    private val onClick: (View, FbPicture) -> Unit,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val inflater = LayoutInflater.from(context)
@@ -108,13 +108,13 @@ class FbPictureAdapter(
         view: View,
         engine: ImageEngine,
         selectionLookUp: (FbPicture) -> Boolean,
-        onClick: (View, FbPicture) -> Unit
+        onClick: (View, FbPicture) -> Unit,
     ) : com.lovoo.android.pickui.adapter.ViewHolder<FbPicture>(
 
         view,
         engine,
         selectionLookUp,
-        onClick
+        onClick,
     ) {
 
         override fun getUri(item: FbPicture): Uri = item.getUri()

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/model/Converter.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/model/Converter.kt
@@ -52,9 +52,9 @@ object Converter {
                             it.id ?: "",
                             it.picture?.data?.url ?: "",
                             it.name ?: "",
-                            it.count?.toLong() ?: 0L
+                            it.count?.toLong() ?: 0L,
                         )
-                    }
+                    },
             )
         }
     }
@@ -74,9 +74,9 @@ object Converter {
                             it.id ?: "",
                             photo.url ?: "",
                             photo.width ?: 0,
-                            photo.height ?: 0
+                            photo.height ?: 0,
                         )
-                    }
+                    },
             )
         }
     }
@@ -93,14 +93,14 @@ object Converter {
         @SerializedName("id") val id: String? = "",
         @SerializedName("name") val name: String? = "",
         @SerializedName("count") val count: Int? = 0,
-        @SerializedName("picture") val picture: FbAlbumData? = null
+        @SerializedName("picture") val picture: FbAlbumData? = null,
     )
 
     /**
      * @param data the album cover
      */
     data class FbAlbumData(
-        @SerializedName("data") val data: FbCover? = null
+        @SerializedName("data") val data: FbCover? = null,
     )
 
     /**
@@ -109,7 +109,7 @@ object Converter {
      */
     data class FbCover(
         @SerializedName("is_silhouette") val isPlaceholder: Boolean? = false,
-        @SerializedName("url") val url: String? = ""
+        @SerializedName("url") val url: String? = "",
     )
 
     /**
@@ -118,7 +118,7 @@ object Converter {
      */
     data class FbPhoto(
         @SerializedName("id") val id: String? = "",
-        @SerializedName("images") val images: List<FbImage>? = emptyList()
+        @SerializedName("images") val images: List<FbImage>? = emptyList(),
     )
 
     /**
@@ -129,6 +129,6 @@ object Converter {
     data class FbImage(
         @SerializedName("source") val url: String? = "",
         @SerializedName("height") val height: Int? = 0,
-        @SerializedName("width") val width: Int? = 0
+        @SerializedName("width") val width: Int? = 0,
     )
 }

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/model/FbPicture.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/model/FbPicture.kt
@@ -31,14 +31,14 @@ data class FbPicture(
     val id: String,
     val url: String,
     val width: Int,
-    val height: Int
+    val height: Int,
 ) : Parcelable {
 
     constructor(parcel: Parcel) : this(
         parcel.readString() ?: "",
         parcel.readString() ?: "",
         parcel.readInt(),
-        parcel.readInt()
+        parcel.readInt(),
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/presenter/FbGalleryPresenterImpl.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/presenter/FbGalleryPresenterImpl.kt
@@ -92,7 +92,7 @@ class FbGalleryPresenterImpl(private val view: FbGalleryView) : FbGalleryPresent
                 override fun onError(error: FacebookException?) {
                     error?.let { view.onError(it) }
                 }
-            }
+            },
         )
     }
 

--- a/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/view/FbPictureFragment.kt
+++ b/pickfacebook/src/main/kotlin/com/lovoo/android/pickfacebook/view/FbPictureFragment.kt
@@ -74,7 +74,7 @@ class FbPictureFragment : Fragment(), FbPictureView {
             adapter = FbPictureAdapter(
                 context,
                 { selectionHolder?.isSelected(it.getUri()) == true },
-                { _, picture -> onPictureClick(picture) }
+                { _, picture -> onPictureClick(picture) },
             )
         }
     }
@@ -94,7 +94,7 @@ class FbPictureFragment : Fragment(), FbPictureView {
                         }
                     }
                 }
-            }
+            },
         )
     }
 

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/GalleryAdapter.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/GalleryAdapter.kt
@@ -40,12 +40,12 @@ import java.io.File
  */
 class GalleryAdapter(
     private val allFolderName: String,
-    private val onClick: (View, Gallery) -> Unit
+    private val onClick: (View, Gallery) -> Unit,
 ) : RecyclerViewCursorAdapter<RecyclerView.ViewHolder>(null) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
-        viewType: Int
+        viewType: Int,
     ): ViewHolder {
         val binding = PickpicListItemGalleryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ViewHolder(binding, allFolderName, onClick)
@@ -74,7 +74,7 @@ class GalleryAdapter(
                             itemView.measuredWidth,
                             Uri.fromFile(File(gallery.coverPath)),
                             galleryCover,
-                            0
+                            0,
                         )
                         return true
                     }

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/PictureAdapter.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/PictureAdapter.kt
@@ -42,7 +42,7 @@ import com.lovoo.android.pickui.R
 class PictureAdapter(
     context: Context,
     private val selectionLookUp: (Picture) -> Boolean,
-    private val onClick: (View, Picture) -> Unit
+    private val onClick: (View, Picture) -> Unit,
 ) : RecyclerViewCursorAdapter<RecyclerView.ViewHolder>(null) {
 
     private val inflater = LayoutInflater.from(context)
@@ -81,13 +81,13 @@ class PictureAdapter(
     private class ViewHolder(
         view: View,
         selectionLookUp: (Picture) -> Boolean,
-        onClick: (View, Picture) -> Unit
+        onClick: (View, Picture) -> Unit,
     ) : com.lovoo.android.pickui.adapter.ViewHolder<Picture>(
 
         view,
         PickPicProvider.imageEngine,
         selectionLookUp,
-        onClick
+        onClick,
     ) {
 
         override fun getUri(item: Picture) = item.getUri()

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/PopUpGalleryAdapter.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/PopUpGalleryAdapter.kt
@@ -39,7 +39,7 @@ import java.io.File
 class PopUpGalleryAdapter(
     private val context: Context,
     private val items: List<Gallery>,
-    private val folderNameLookUp: (Gallery) -> String
+    private val folderNameLookUp: (Gallery) -> String,
 ) : BaseAdapter() {
 
     private val inflater = LayoutInflater.from(context)
@@ -47,7 +47,7 @@ class PopUpGalleryAdapter(
     override fun getView(
         position: Int,
         convertView: View?,
-        container: ViewGroup
+        container: ViewGroup,
     ): View {
         val item = getItem(position) ?: return View(context)
         val binding = convertView?.let { PickpicListItemGalleryBinding.bind(it) } ?: PickpicListItemGalleryBinding.inflate(inflater, container, false)
@@ -61,7 +61,11 @@ class PopUpGalleryAdapter(
                         false -> Uri.parse(item.coverPath)
                     }
                     PickPicProvider.imageEngine.loadThumbnail(
-                        context, galleryCover.measuredHeight, uri, galleryCover, 0
+                        context,
+                        galleryCover.measuredHeight,
+                        uri,
+                        galleryCover,
+                        0,
                     )
                     return true
                 }

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/ViewHolder.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/adapter/ViewHolder.kt
@@ -41,7 +41,7 @@ abstract class ViewHolder<T>(
     view: View,
     private val engine: ImageEngine,
     private val selectionLookUp: (T) -> Boolean,
-    private val onClick: (View, T) -> Unit
+    private val onClick: (View, T) -> Unit,
 ) : RecyclerView.ViewHolder(view) {
 
     private val size = MutableLiveData<Int>()
@@ -75,7 +75,7 @@ abstract class ViewHolder<T>(
             PlaceHolderDrawable().apply {
                 this.width = width
                 this.height = width
-            }
+            },
         )
     }
 

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/view/GalleryFragment.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/view/GalleryFragment.kt
@@ -22,7 +22,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.database.Cursor
-import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -77,7 +76,6 @@ class GalleryFragment : Fragment(), GalleryView {
         presenter.onCreate(savedInstanceState)
     }
 
-
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -87,7 +85,7 @@ class GalleryFragment : Fragment(), GalleryView {
         val filter = IntentFilter().apply {
             addAction(CameraLoader.INTENT_INVALIDATE_GALLERY)
         }
-        context.registerReceiverSafely(receiver = invalidateReceiver, filter = filter,)
+        context.registerReceiverSafely(receiver = invalidateReceiver, filter = filter)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/view/GalleryFragment.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/view/GalleryFragment.kt
@@ -15,12 +15,14 @@
  */
 package com.lovoo.android.pickui.view
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.database.Cursor
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -37,6 +39,7 @@ import com.lovoo.android.pickcore.model.Gallery
 import com.lovoo.android.pickcore.model.convertToUi
 import com.lovoo.android.pickcore.permission.Permission
 import com.lovoo.android.pickcore.presenter.GalleryPresenterImpl
+import com.lovoo.android.pickcore.util.registerReceiverSafely
 import com.lovoo.android.pickui.R
 import com.lovoo.android.pickui.adapter.GalleryAdapter
 import com.lovoo.android.pickui.adapter.PopUpGalleryAdapter
@@ -74,6 +77,8 @@ class GalleryFragment : Fragment(), GalleryView {
         presenter.onCreate(savedInstanceState)
     }
 
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     override fun onAttach(context: Context) {
         super.onAttach(context)
         activity?.let {
@@ -82,7 +87,7 @@ class GalleryFragment : Fragment(), GalleryView {
         val filter = IntentFilter().apply {
             addAction(CameraLoader.INTENT_INVALIDATE_GALLERY)
         }
-        context.registerReceiver(invalidateReceiver, filter)
+        context.registerReceiverSafely(receiver = invalidateReceiver, filter = filter,)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/view/PictureDecoration.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/view/PictureDecoration.kt
@@ -25,7 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
  */
 class PictureDecoration(
     private val spanCount: Int,
-    private val padding: Int
+    private val padding: Int,
 ) : RecyclerView.ItemDecoration() {
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/view/PictureFragment.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/view/PictureFragment.kt
@@ -38,6 +38,7 @@ import com.lovoo.android.pickcore.model.Gallery
 import com.lovoo.android.pickcore.model.Picture
 import com.lovoo.android.pickcore.model.convertToUi
 import com.lovoo.android.pickcore.presenter.PicturePresenterImpl
+import com.lovoo.android.pickcore.util.registerReceiverSafely
 import com.lovoo.android.pickui.R
 import com.lovoo.android.pickui.adapter.PictureAdapter
 import com.lovoo.android.pickui.databinding.PickpicFragmentPictureBinding
@@ -111,7 +112,7 @@ class PictureFragment : Fragment(), PictureView {
         val filter = IntentFilter().apply {
             addAction(CameraLoader.INTENT_INVALIDATE_GALLERY)
         }
-        context.registerReceiver(invalidateReceiver, filter)
+        context.registerReceiverSafely(invalidateReceiver, filter)
     }
 
     override fun onDetach() {

--- a/pickui/src/main/kotlin/com/lovoo/android/pickui/view/PictureFragment.kt
+++ b/pickui/src/main/kotlin/com/lovoo/android/pickui/view/PictureFragment.kt
@@ -84,7 +84,7 @@ class PictureFragment : Fragment(), PictureView {
             adapter = PictureAdapter(
                 context,
                 { selectionHolder?.isSelected(it.getUri()) == true },
-                { _, picture -> onPictureClick(picture) }
+                { _, picture -> onPictureClick(picture) },
             )
         }
     }
@@ -107,7 +107,7 @@ class PictureFragment : Fragment(), PictureView {
                         }
                     }
                 }
-            }
+            },
         )
         val filter = IntentFilter().apply {
             addAction(CameraLoader.INTENT_INVALIDATE_GALLERY)

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -1,6 +1,6 @@
-apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: "com.diffplug.spotless"
 
-ext.ktlint_version = "0.37.2"
+ext.ktlint_version = "0.48.0"
 
 spotless {
     kotlin {


### PR DESCRIPTION
- Added explicit RECEIVER_EXPORTED and RECEIVER_NOT_EXPORTED flags for registering broadcast receivers
- Gradle version upgrade to 7.4.2 to support new version of Spotless. Kotlin and Spotless upgrades. Code style refactoring (automated by Spotless)